### PR TITLE
Please enable issues

### DIFF
--- a/temp.md
+++ b/temp.md
@@ -1,0 +1,32 @@
+This is an error I get running ` yo @atxm/package`
+
+```
+internal/modules/cjs/loader.js:979
+  throw err;
+  ^
+
+Error: Cannot find module '../../lib/helpers'
+Require stack:
+- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\@atxm\generator-package\generators\app\index.js
+- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\node_modules\yeoman-environment\lib\store.js
+- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\node_modules\yeoman-environment\lib\environment.js
+- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\lib\router.js
+- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\lib\cli.js
+    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:976:15)
+    at Function.Module._load (internal/modules/cjs/loader.js:859:27)
+    at Module.require (internal/modules/cjs/loader.js:1036:19)
+    at require (internal/modules/cjs/helpers.js:72:18)
+    at Object.<anonymous> (C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\@atxm\generator-package\generators\app\index.js:20:5)
+    at Module._compile (internal/modules/cjs/loader.js:1147:30)
+    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
+    at Module.load (internal/modules/cjs/loader.js:996:32)
+    at Function.Module._load (internal/modules/cjs/loader.js:896:14)
+    at Module.require (internal/modules/cjs/loader.js:1036:19) {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: [
+    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\@atxm\\generator-package\\generators\\app\\index.js',
+    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\node_modules\\yeoman-environment\\lib\\store.js',
+    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\node_modules\\yeoman-environment\\lib\\environment.js',
+    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\lib\\router.js',
+    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\lib\\cli.js'
+    ```


### PR DESCRIPTION
This is an error I get running ` yo @atxm/package`

```
internal/modules/cjs/loader.js:979
  throw err;
  ^
Error: Cannot find module '../../lib/helpers'
Require stack:
- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\@atxm\generator-package\generators\app\index.js
- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\node_modules\yeoman-environment\lib\store.js
- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\node_modules\yeoman-environment\lib\environment.js
- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\lib\router.js
- C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\yo\lib\cli.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:976:15)
    at Function.Module._load (internal/modules/cjs/loader.js:859:27)
    at Module.require (internal/modules/cjs/loader.js:1036:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (C:\Users\yahyaaba\AppData\Roaming\npm\node_modules\@atxm\generator-package\generators\app\index.js:20:5)
    at Module._compile (internal/modules/cjs/loader.js:1147:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:996:32)
    at Function.Module._load (internal/modules/cjs/loader.js:896:14)
    at Module.require (internal/modules/cjs/loader.js:1036:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\@atxm\\generator-package\\generators\\app\\index.js',
    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\node_modules\\yeoman-environment\\lib\\store.js',
    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\node_modules\\yeoman-environment\\lib\\environment.js',
    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\lib\\router.js',
    'C:\\Users\\yahyaaba\\AppData\\Roaming\\npm\\node_modules\\yo\\lib\\cli.js'
    ```